### PR TITLE
fix(security): update toml in .opencode + monitor second lockfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,28 @@ updates:
     # Per ricevere anche security updates automatiche, abilitare
     # "Dependabot security updates" nelle impostazioni repo (non versionabile).
 
+  # Secondo lockfile del repo (framework OpenCode): senza questa entry le
+  # vulnerabilita' in .opencode/package-lock.json non generano PR (lezione 2026-09-09).
+  - package-ecosystem: npm
+    directory: "/.opencode"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Rome
+    target-branch: main
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      opencode-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -314,9 +314,9 @@
       }
     },
     "node_modules/toml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
-      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz",
+      "integrity": "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==",
       "license": "MIT",
       "engines": {
         "node": ">=20"


### PR DESCRIPTION
## Summary

Chiude gli ultimi 2 Dependabot alerts aperti (\#1, \#2: toml in `.opencode/package-lock.json`).

## Changes

- `toml 4.1.1 -> 4.3.0` in `.opencode/package-lock.json` (CVE-2026-63376, CVE-2026-77465; audit locale: 0 vulnerabilita')
- `dependabot.yml`: aggiunto monitoraggio `/.opencode` (fix sistemico — senza, quel lockfile era invisibile a Dependabot)

## Note

Gli advisory non indicano ancora una versione patched ufficiale; applicata l'ultima 4.x compatibile con `effect ^4.1.1`. Se GitHub pubblichera' un fix diverso, Dependabot aprira' PR automaticamente (ora monitora anche quella directory).