### PR TITLE
fix(tests): stray brace breaking CodeQL extraction

### DIFF
--- a/frontend/patterns/templates/__tests__/confirm-destructive-action.test.tsx
+++ b/frontend/patterns/templates/__tests__/confirm-destructive-action.test.tsx
@@ -228,7 +228,6 @@ describe('CountdownConfirmDialog', () => {
     expect(screen.getByText('0')).toBeDefined()
     expect(screen.getByTestId('confirm-btn').getAttribute('disabled')).toBeNull()
   })
-})
 
   it('TypeToConfirm error resets input', () => {
     render(<TypeToConfirmDialog {...defaultProps} confirmWord="CONFIRMA" />)


### PR DESCRIPTION
## Summary

Rimuove una `})` orfana in `confirm-destructive-action.test.tsx` che chiudeva in anticipo il describe `CountdownConfirmDialog`, lasciando due `it` fuori posto e una `})` pendente. Il file non parsava: CodeQL riportava 2 syntax-error diagnostics ("Could not process some files") nella pagina di stato.

## Verification

- Tutti i 66 file TS/TSX del repo passano il transpile check
- Suite esistente: 37/37 verde